### PR TITLE
Handle properties with string keys in requireEnhancedObjectLiterals rule.

### DIFF
--- a/lib/rules/require-enhanced-object-literals.js
+++ b/lib/rules/require-enhanced-object-literals.js
@@ -13,12 +13,14 @@ module.exports.prototype = {
 
   check: function(file, errors) {
     file.iterateNodesByType('Property', function(node) {
-      var propertyName = node.key.name;
+      // node.key.name is used when the property key is an unquoted identifier
+      // node.key.value is used when the property key is a quoted string
+      var propertyName = node.key.name || node.key.value;
       var valueName = node.value.name;
       var shorthand = node.shorthand;
 
       // check for non-shorthand properties
-      if (propertyName === valueName && !shorthand) {
+      if (propertyName && propertyName === valueName && !shorthand) {
         errors.add(
           'Property assignment should use enhanced object literal function. `{ propName: propName}` is not allowed.',
           node.loc.start

--- a/tests/fixtures/require-enhanced-object-literals/bad/duplicate-string-property-name-and-value.js
+++ b/tests/fixtures/require-enhanced-object-literals/bad/duplicate-string-property-name-and-value.js
@@ -1,0 +1,5 @@
+let blah = 'foo';
+
+let myObject = {
+  'blah': blah
+};

--- a/tests/fixtures/require-enhanced-object-literals/good/example.js
+++ b/tests/fixtures/require-enhanced-object-literals/good/example.js
@@ -4,3 +4,11 @@ let myObject = {
   someProperty,
   someFunction() {}
 };
+
+let otherObject = {
+  'stringProp': {}
+};
+
+let thing2 = {
+  'stringProp': 'some other string value'
+};


### PR DESCRIPTION
Prior to this, usage of string keys such as:

```javascript
let blah = 'blah blah';

let myObject = {
  'blah': 'some other value'
};
```

Was always failing the test and caused an error (even when the property key did not match the value).