### PR TITLE
Fix issue with `let { get } = Ember;`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ module.exports = {
     var customRulePath = path.join(__dirname, 'lib', 'rules');
     jscsConfig.additionalRules = [path.join(customRulePath, '*.js')];
 
+    var esprimaPath = require.resolve('esprima');
+    jscsConfig.esprima = esprimaPath;
+
     var info = temp.openSync('ember-suave');
     fs.writeSync(info.fd, JSON.stringify(jscsConfig));
     fs.closeSync(info.fd);

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "broccoli-jscs": "0.0.22",
     "ember-cli-babel": "^5.0.0",
+    "esprima": "^2.2.0",
     "temp": "^0.8.1"
   },
   "ember-addon": {

--- a/tests/fixtures/get-set-destructuring-regression/good/example.js
+++ b/tests/fixtures/get-set-destructuring-regression/good/example.js
@@ -1,0 +1,5 @@
+let { get, set } = Ember;
+
+let { get } = Ember;
+
+let { set } = Ember;

--- a/tests/rules-test.js
+++ b/tests/rules-test.js
@@ -45,10 +45,12 @@ describe('rules tests', function() {
       it('bad files should fail', function() {
         var rulePath = path.join(fixturePath, dir, 'bad');
 
-        return checkJSCSRules(this.lintTree('test', rulePath), function(contents) {
-          expect(contents).to.not.include('ok(true');
-          expect(contents).to.include('ok(false');
-        });
+        if (fs.existsSync(rulePath)) {
+          return checkJSCSRules(this.lintTree('test', rulePath), function(contents) {
+            expect(contents).to.not.include('ok(true');
+            expect(contents).to.include('ok(false');
+          });
+        }
       });
     });
   });


### PR DESCRIPTION
The issue was fixed upstream in the latests Esprima, but JSCS is locked to an older version. We can override the Esprima used by JSCS by providing the path to our custom version in `"esprima"` key of the
JSCS config file.

Thanks to @hzoo's help in https://github.com/jscs-dev/node-jscs/issues/1293 for suggesting the work around.