### PR TITLE
New rule: `requireObjectDestructuring`

### DIFF
--- a/lib/jscsrc.json
+++ b/lib/jscsrc.json
@@ -35,6 +35,9 @@
   ],
   "requireDotNotation": true,
   "requireEnhancedObjectLiterals": true,
+  "requireObjectDestructuring": {
+    "allExcept": ["get", "set"]
+  },
   "requireSemicolons": true,
   "requireSpaceAfterBinaryOperators": true,
   "requireSpaceAfterKeywords": [

--- a/lib/rules/require-object-destructuring.js
+++ b/lib/rules/require-object-destructuring.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+  configure: function(option) {
+    var isTrue = option === true;
+
+    assert(
+      isTrue || (typeof option === 'object' && Array.isArray(option.allExcept)),
+      this.getOptionName() + ' requires the value `true` ' +
+        'or an object with an `allExcept` array property'
+    );
+
+    this._propertyExceptions = !isTrue && option.allExcept || [];
+  },
+
+  getOptionName: function() {
+    return 'requireObjectDestructuring';
+  },
+
+  check: function(file, errors) {
+    var propertyExceptions = this._propertyExceptions;
+
+    file.iterateNodesByType('VariableDeclaration', function(node) {
+
+      node.declarations.forEach(function(declaration) {
+        if (!declaration.init || declaration.init.type !== 'MemberExpression') {
+          return;
+        }
+
+        var variable = declaration.id || {};
+        var property = declaration.init.property || {};
+
+        if (variable.name === property.name &&
+            propertyExceptions.indexOf(variable.name) < 0) {
+
+          errors.add('Property assignments should use destructuring', node.loc.start);
+        }
+      });
+    });
+  }
+};

--- a/tests/fixtures/rules/require-object-destructuring/bad/example.js
+++ b/tests/fixtures/rules/require-object-destructuring/bad/example.js
@@ -1,0 +1,2 @@
+let foo = SomeThing.foo;
+let bar = SomeThing.Baz.bar;

--- a/tests/fixtures/rules/require-object-destructuring/good/example.js
+++ b/tests/fixtures/rules/require-object-destructuring/good/example.js
@@ -1,0 +1,7 @@
+let { foo } = SomeThing;
+let { bar } = SomeThing.Baz;
+
+let someVariableName = SomeThing.propertyWithDifferentName;
+
+const get = SomeThing.get;
+const set = SomeThing.set;


### PR DESCRIPTION
This rule will enforce the use of object destructuring when it detects that the local variable name matches the object property name. Exceptions for property names may be specified.