### PR TITLE
Add object destructuring test cases for `requireEnhancedObjectLiterals`.

### DIFF
--- a/tests/fixtures/rules/require-enhanced-object-literals/bad/object-destructuring.js
+++ b/tests/fixtures/rules/require-enhanced-object-literals/bad/object-destructuring.js
@@ -1,0 +1,1 @@
+let { foo: foo } = SomeThing;

--- a/tests/fixtures/rules/require-enhanced-object-literals/good/example.js
+++ b/tests/fixtures/rules/require-enhanced-object-literals/good/example.js
@@ -12,3 +12,5 @@ let otherObject = {
 let thing2 = {
   'stringProp': 'some other string value'
 };
+
+let { foo } = SomeThing;


### PR DESCRIPTION
* Bad/good case to show that the rule covers object destructuring

Closes #23