### PR TITLE
Re-enable requireLineBreakAfterVariableAssignment rule.

### DIFF
--- a/lib/jscsrc.json
+++ b/lib/jscsrc.json
@@ -35,6 +35,7 @@
   ],
   "requireDotNotation": true,
   "requireEnhancedObjectLiterals": true,
+  "requireLineBreakAfterVariableAssignment": true,
   "requireObjectDestructuring": {
     "allExcept": ["get", "set"]
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
     "ember-try": "0.0.4",
-    "jscs": "^1.12.0",
+    "jscs": "^1.13.0",
     "mocha": "^2.2.4",
     "mocha-jshint": "^2.1.1",
     "walk-sync": "^0.1.3"

--- a/tests/fixtures/rules/require-line-break-after-variable-assignment/bad/const.js
+++ b/tests/fixtures/rules/require-line-break-after-variable-assignment/bad/const.js
@@ -1,0 +1,1 @@
+const abc = 2; const blah = 5;

--- a/tests/fixtures/rules/require-line-break-after-variable-assignment/bad/let.js
+++ b/tests/fixtures/rules/require-line-break-after-variable-assignment/bad/let.js
@@ -1,0 +1,1 @@
+let abc = 1; let foo = 2;

--- a/tests/fixtures/rules/require-line-break-after-variable-assignment/good/example.js
+++ b/tests/fixtures/rules/require-line-break-after-variable-assignment/good/example.js
@@ -1,0 +1,2 @@
+const foo = 1;
+let bar = 2;


### PR DESCRIPTION
JSCS 1.13.0 has been released, and the requireLineBreakAfterVariableAssignment rule has been updated to account for `let` and `const` properly.

Fixes #4.