### PR TITLE
Require @private/@public in all block comments.

### DIFF
--- a/lib/jscsrc.json
+++ b/lib/jscsrc.json
@@ -24,6 +24,7 @@
   "requireCamelCaseOrUpperCaseIdentifiers": true,
   "requireCapitalizedConstructors": true,
   "requireCommaBeforeLineBreak": true,
+  "requireCommentsToIncludeAccess": true,
   "requireCurlyBraces": [
     "if",
     "else",

--- a/lib/rules/require-comments-to-include-access.js
+++ b/lib/rules/require-comments-to-include-access.js
@@ -1,0 +1,30 @@
+var assert = require('assert');
+
+function includesAccessDeclaration(comment) {
+  return comment.value.match(/\n\s*(@private|@public)\s/);
+}
+
+function RequireCommentsToIncludeAccess() { }
+
+RequireCommentsToIncludeAccess.prototype = {
+  configure: function(value) {
+    assert(
+      value === true,
+      this.getOptionName() + ' option requires a true value or should be removed'
+    );
+  },
+
+  getOptionName: function() {
+    return 'requireCommentsToIncludeAccess';
+  },
+
+  check: function(file, errors) {
+    file.iterateTokensByType('Block', function(comment) {
+      if (!includesAccessDeclaration(comment)) {
+        errors.add('You must supply `@public` or `@private` for block comments.', comment.loc.start);
+      }
+    });
+  }
+};
+
+module.exports = RequireCommentsToIncludeAccess;

--- a/tests/fixtures/rules/require-comments-to-include-access/bad/with-access-phrase-used-in-verbiage-not-standalone.js
+++ b/tests/fixtures/rules/require-comments-to-include-access/bad/with-access-phrase-used-in-verbiage-not-standalone.js
@@ -1,0 +1,5 @@
+/**
+  This thing has @private and @public in the text description but not
+  as an actual YUIDoc attribute.
+*/
+export function ambiguousThing() {}

--- a/tests/fixtures/rules/require-comments-to-include-access/bad/without-access-declaration.js
+++ b/tests/fixtures/rules/require-comments-to-include-access/bad/without-access-declaration.js
@@ -1,0 +1,4 @@
+/**
+  Something without access documented.
+*/
+export function someNonDeterminedThing() {}

--- a/tests/fixtures/rules/require-comments-to-include-access/good/example.js
+++ b/tests/fixtures/rules/require-comments-to-include-access/good/example.js
@@ -1,0 +1,15 @@
+/**
+
+ This thing is private.
+
+ @private
+ */
+export function somePrivateThing() {}
+
+/**
+
+ This thing is public.
+
+ @public
+ */
+export function somePublicThing() {}


### PR DESCRIPTION
Enforce all block comments to include YUIDoc style `@private` or `@public` access declaration.

```
// good

/**

 This thing is private.

 @private
*/
export function somePrivateThing() {}

/**

 This thing is private.

 @public
*/
export function somePublicThing() {}

// bad

/**
  Something without access documented.
*/
export function someNonDeterminedThing() {}

/**
  This thing has @private and @public in the text description but not
  as an actual YUIDoc attribute.
*/
export function ambiguousThing() {}
```