### PR TITLE
Properly check for object destructuring when the key is a string.

### DIFF
--- a/lib/rules/require-object-destructuring.js
+++ b/lib/rules/require-object-destructuring.js
@@ -25,15 +25,17 @@ module.exports.prototype = {
     file.iterateNodesByType('VariableDeclaration', function(node) {
 
       node.declarations.forEach(function(declaration) {
-        if (!declaration.init || declaration.init.type !== 'MemberExpression') {
+        var declarationId = declaration.id || {};
+        var declarationInit = declaration.init || {};
+
+        if (declarationId.type !== 'Identifier' || declarationInit.type !== 'MemberExpression') {
           return;
         }
 
-        var variable = declaration.id || {};
-        var property = declaration.init.property || {};
+        var propertyName = declarationInit.property && declarationInit.property.name;
 
-        if (variable.name === property.name &&
-            propertyExceptions.indexOf(variable.name) < 0) {
+        if (declarationId.name === propertyName &&
+            propertyExceptions.indexOf(propertyName) < 0) {
 
           errors.add('Property assignments should use destructuring', node.loc.start);
         }

--- a/tests/fixtures/rules/require-object-destructuring/bad/string-property.js
+++ b/tests/fixtures/rules/require-object-destructuring/bad/string-property.js
@@ -1,0 +1,1 @@
+const val = SomeThing['some.key'].val;

--- a/tests/fixtures/rules/require-object-destructuring/good/example.js
+++ b/tests/fixtures/rules/require-object-destructuring/good/example.js
@@ -5,3 +5,5 @@ let someVariableName = SomeThing.propertyWithDifferentName;
 
 const get = SomeThing.get;
 const set = SomeThing.set;
+
+const { val } = SomeThing['some.key'];


### PR DESCRIPTION
Closes #35.