### PR TITLE
[BUGFIX] Ensure comment access rules only apply to YUIDoc blocks.

### DIFF
--- a/lib/rules/require-comments-to-include-access.js
+++ b/lib/rules/require-comments-to-include-access.js
@@ -1,5 +1,9 @@
 var assert = require('assert');
 
+function isDocComment(comment) {
+  return comment.value[0] === '*';
+}
+
 function includesAccessDeclaration(comment) {
   return comment.value.match(/\n\s*(@private|@public)\s/);
 }
@@ -20,7 +24,7 @@ RequireCommentsToIncludeAccess.prototype = {
 
   check: function(file, errors) {
     file.iterateTokensByType('Block', function(comment) {
-      if (!includesAccessDeclaration(comment)) {
+      if (isDocComment(comment) && !includesAccessDeclaration(comment)) {
         errors.add('You must supply `@public` or `@private` for block comments.', comment.loc.start);
       }
     });

--- a/tests/fixtures/rules/require-comments-to-include-access/good/example.js
+++ b/tests/fixtures/rules/require-comments-to-include-access/good/example.js
@@ -13,3 +13,7 @@ export function somePrivateThing() {}
  @public
  */
 export function somePublicThing() {}
+
+/*
+ Some non documentation block, nothing to see here.
+*/


### PR DESCRIPTION
Ensures that comment blocks without 2 stars are not enforced to include
access control comment.

```javascript
/*
  This is ok now.
*/
```