### PR TITLE
Allow JSCS to run stand-alone (ensure ember-suave custom rules are only declared once)

### DIFF
--- a/lib/jscsrc-builder.js
+++ b/lib/jscsrc-builder.js
@@ -43,6 +43,17 @@ function mergeConfigs(userConfig, suaveConfig) {
   return config;
 }
 
+function hasEmberSuaveCustomRules(additionalRules) {
+  var regex = /\/ember-suave\/lib\/rules\/\*\.js$/;
+
+  for (var i = 0; i < additionalRules.length; i++) {
+    if (additionalRules[i].match(regex)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 module.exports = function(project) {
   var userConfig = getCustomConfig();
   var suaveConfig = require('./jscsrc');
@@ -56,9 +67,11 @@ module.exports = function(project) {
     return path.resolve(projectRoot, rulePath);
   });
 
-  // Addon custom rules
-  var customRulePath = path.join(__dirname, 'rules');
-  jscsConfig.additionalRules.push(path.join(customRulePath, '*.js'));
+  // Addon custom rules unless userConfig already included them
+  if (!hasEmberSuaveCustomRules(jscsConfig.additionalRules)) {
+    var customRulePath = path.join(__dirname, 'rules');
+    jscsConfig.additionalRules.push(path.join(customRulePath, '*.js'));
+  }
 
   var info = temp.openSync('ember-suave');
   fs.writeSync(info.fd, JSON.stringify(jscsConfig));

--- a/tests/jscsrc-builder-test.js
+++ b/tests/jscsrc-builder-test.js
@@ -61,6 +61,29 @@ describe('jscsrc-builder', function() {
     expect(config.additionalRules).to.include(expectedRulePath);
   });
 
+  it('default `additionalRules` only has ember-suave custom rules', function() {
+    var project = { root: '/fake/project/root' };
+    var configPath = jscsrcBuilder(project);
+    var config = readConfig(configPath);
+
+    expect(config.additionalRules.length).to.equal(1);
+
+    var regex = /\/ember-suave\/lib\/rules\/\*\.js$/;
+    expect(config.additionalRules[0]).to.match(regex);
+  });
+
+  it('ember-suave custom rules wont be added twice to `additionalRules` ', function() {
+    testCustomConfig({
+      additionalRules: ['./node_modules/ember-suave/lib/rules/*.js']
+    });
+
+    var project = { root: '/fake/project/root' };
+    var configPath = jscsrcBuilder(project);
+    var config = readConfig(configPath);
+
+    expect(config.additionalRules.length).to.equal(1);
+  });
+
   it('uses a users esprima if present', function() {
     testCustomConfig({
       esprima: 'foo-bar'


### PR DESCRIPTION
Currently, stand-alone JSCS linting doesn't work with ember-suave because of the custom `additionalRules` used by ember-suave.  So, this PR allows you to specify the ember-suave custom rules in your `.jscsrc` as `additionalRules` without breaking the brocolli build that also wants to add the ember-suave custom rules.

Running stand-alone JSCS is very handy if your editor supports JSCS linting (I'm using this with sublime text 3)

This PR addresses https://github.com/dockyard/ember-suave/issues/43
