### PR TITLE
Default to showing the rule name next to each error message.

### DIFF
--- a/lib/jscsrc.json
+++ b/lib/jscsrc.json
@@ -1,5 +1,6 @@
 {
   "esnext": true,
+  "verbose": true,
 
   "disallowEmptyBlocks": true,
   "disallowSpacesBeforeSemicolons": true,


### PR DESCRIPTION
When a piece of code does not pass JSCS and we want to ignore the rule or modify its config, we don't have to track down what its name is.