### PR TITLE
Upgrade to JSCS 2.0

### DIFF
--- a/lib/jscsrc.json
+++ b/lib/jscsrc.json
@@ -39,9 +39,7 @@
   "requireDotNotation": true,
   "requireEnhancedObjectLiterals": true,
   "requireLineBreakAfterVariableAssignment": true,
-  "requireObjectDestructuring": {
-    "allExcept": ["get", "set"]
-  },
+  "requireObjectDestructuring": true,
   "requireSemicolons": true,
   "requireSpaceAfterBinaryOperators": true,
   "requireSpaceAfterKeywords": [

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chai": "^2.2.0",
     "ember-cli": "1.13.1",
     "ember-cli-release": "^0.2.3",
-    "jscs": "^1.13.0",
+    "jscs": "^2.0.0",
     "mocha": "^2.2.4",
     "mocha-jshint": "^2.1.1",
     "walk-sync": "0.1.3"
@@ -35,7 +35,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "broccoli-jscs": "0.0.22",
+    "broccoli-jscs": "^1.0.0",
     "ember-cli-babel": "^5.0.0",
     "temp": "^0.8.1"
   },

--- a/tests/fixtures/rules/require-object-destructuring/good/example.js
+++ b/tests/fixtures/rules/require-object-destructuring/good/example.js
@@ -3,7 +3,7 @@ let { bar } = SomeThing.Baz;
 
 let someVariableName = SomeThing.propertyWithDifferentName;
 
-const get = SomeThing.get;
-const set = SomeThing.set;
+const { get } = SomeThing;
+const { set } = SomeThing;
 
 const { val } = SomeThing['some.key'];

--- a/tests/fixtures/rules/require-space-after-keywords/good/example.js
+++ b/tests/fixtures/rules/require-space-after-keywords/good/example.js
@@ -25,6 +25,8 @@ try {
   console.log(error);
 }
 
-return { a: 'abc' };
+function foo() {
+  return { a: 'abc' };
+}
 
 console.log(typeof ['a', 'b'] === 'object');


### PR DESCRIPTION
* Upgrade to `broccoli-jscs@1.0.0` for JSCS 2.0 support
* Fix test example code for `require-space-after-keywords` rule:
  - The new parser requires wrapping the example `return` statement in a
    function.
* Update the `require-object-destructuring` rule:
  - Remove the exception made to `get` and `set` as the
    [issue](https://github.com/jscs-dev/node-jscs/issues/1293) has been
resolved in the Esprima version that JSCS now uses.

Closes #49.