### PR TITLE
Add space in requireEnhancedObjectLiterals error

### DIFF
--- a/lib/rules/require-enhanced-object-literals.js
+++ b/lib/rules/require-enhanced-object-literals.js
@@ -22,7 +22,7 @@ module.exports.prototype = {
       // check for non-shorthand properties
       if (propertyName && propertyName === valueName && !shorthand) {
         errors.add(
-          'Property assignment should use enhanced object literal function. `{ propName: propName}` is not allowed.',
+          'Property assignment should use enhanced object literal function. `{ propName: propName }` is not allowed.',
           node.loc.start
         );
       }


### PR DESCRIPTION
This adds a missing space to the second } in the error message for consistency.