### PR TITLE
Add disable jscs option to qunit

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "vendor"
+}

--- a/index.js
+++ b/index.js
@@ -1,16 +1,23 @@
 /* jshint node: true */
 'use strict';
-
 var JSCSFilter = require('broccoli-jscs');
 var jscsrcBuilder = require('./lib/jscsrc-builder');
 
 module.exports = {
   name: 'ember-suave',
 
-  lintTree: function(type, tree) {
+  lintTree: function (type, tree) {
     var jscsOptions = this.app.options.jscsOptions || {};
     jscsOptions.configPath = jscsrcBuilder(this.project);
-
     return new JSCSFilter(tree, jscsOptions);
+  },
+
+  included: function(app) {
+    this._super.included.apply(this, arguments);
+    if (app.tests) {
+      app.import('vendor/ember-suave/qunit-configuration.js', { type: 'test' });
+      app.import('vendor/ember-suave/test-loader.js', { type: 'test' });
+    }
   }
+
 };

--- a/vendor/ember-suave/qunit-configuration.js
+++ b/vendor/ember-suave/qunit-configuration.js
@@ -1,0 +1,4 @@
+/* globals QUnit */
+if (QUnit) {
+  QUnit.config.urlConfig.push({ id: 'nojscs', label: 'Disable JSCS' });
+}

--- a/vendor/ember-suave/test-loader.js
+++ b/vendor/ember-suave/test-loader.js
@@ -1,0 +1,15 @@
+/* globals jQuery, QUnit */
+
+jQuery(document).ready(function () {
+  var TestLoaderModule = require('ember-cli/test-loader');
+  var addModuleExcludeMatcher = TestLoaderModule['addModuleExcludeMatcher'];
+
+  function isJscsDisabled() { return QUnit ? QUnit.urlParams.nojscs : false; }
+  function isAJscsTest(moduleName) { return moduleName.match(/\.jscs-test$/); }
+  function jscsModuleMatcher(moduleName) { return isJscsDisabled() && isAJscsTest(moduleName); }
+
+  if (addModuleExcludeMatcher) {
+    addModuleExcludeMatcher(jscsModuleMatcher);
+  }
+
+});


### PR DESCRIPTION
Fix for Issue https://github.com/dockyard/ember-suave/issues/62

I added a checkbox to qunit -> "Disable JSCS"
When checked, none of the Suave JSCS tests are run.

I added 2 cases for disabling:
* one that sets an addModuleIncludeMatcher added by @rwjblue as part of ember-cli-qunit pull request https://github.com/ember-cli/ember-cli-qunit/pull/77
* one that sets the prototype of test-loader for shouldLoadModule if addModuleIncludeMatcher is not there (prior to above pull request)