### PR TITLE
Add global namespace to Qunit check

### DIFF
--- a/vendor/ember-suave/qunit-configuration.js
+++ b/vendor/ember-suave/qunit-configuration.js
@@ -1,4 +1,4 @@
-/* globals QUnit */
-if (QUnit) {
-  QUnit.config.urlConfig.push({ id: 'nojscs', label: 'Disable JSCS' });
+/* globals self */
+if (self.QUnit) {
+  self.QUnit.config.urlConfig.push({ id: 'nojscs', label: 'Disable JSCS' });
 }


### PR DESCRIPTION
When using an alternative test framework (Mocha) Qunit is not a global variable.