### PR TITLE
Use JSCS preset system instead of generating custom build config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "stable"
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,26 @@ Ember style guide rules.
 * [JavaScript Style Guide](https://github.com/dockyard/styleguides/blob/master/javascript.md)
 * [Ember Style Guide](https://github.com/dockyard/styleguides/blob/master/ember.md)
 
+## Installation
+
+```bash
+ember install ember-suave
+```
+
 ## Usage
 
-* ember-cli >= 0.2.3 `ember install ember-suave`
-* ember-cli < 0.2.3 `ember install:addon ember-suave`
+`ember-suave` is used as a JSCS preset, and can be enabled by adding a `preset` to your `.jscsrc` file.
+
+```
+{
+  "preset": "ember-suave"
+}
+```
+
+`ember-suave` integrates well with ember-cli, but can also be used as a standalone JSCS preset. This allows custom
+editor integration, and non-ember-cli projects to utilize our curated set of rules.
+
+When used from within ember-cli, your test suite will automatically fail if any of the rules are broken.
 
 ## JSCS Rules
 
@@ -25,19 +41,21 @@ so that all you need to do is install the addon and start writing stylish code.
 ### Customization
 
 If `ember-suave` isn't suave enough for you and you'd like to override
-certain rules, simply provide your own `.jscsrc` file at the root of
-your Ember CLI project. Those rules will be merged with the ones in the
-default config.
+certain rules, simply add your own rules to `.jscsrc` at the root of
+your Ember CLI project. Those rules will take precedence over the ones in the
+default preset.
 
 You can specify any of the [rules](http://jscs.info/rules.html) that are
-built into JSCS, or even provide your own custom ones.
+built into JSCS, provide your own custom ones, or even override the ones we
+have enabled by default.
 
 To disable a rule, set its value to `null`.
 
 ```json
 // .jscsrc
 {
-  "additionalRules": ["lib/rules/*.js"],
+  "preset": "ember-suave",
+  "additionalRules": ["./lib/rules/*.js"],
   "myAwesomeCustomRule": true,
   "disallowDanglingUnderscores": true,
   "disallowEmptyBlocks": null

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/ember-suave/files/.jscsrc
+++ b/blueprints/ember-suave/files/.jscsrc
@@ -1,0 +1,3 @@
+{
+  "preset": "ember-suave"
+}

--- a/blueprints/ember-suave/index.js
+++ b/blueprints/ember-suave/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  description: 'ember-suave install generator',
+
+  normalizeEntityName: function() {
+    // this prevents an error when the entityName is
+    // not specified (since that doesn't actually matter
+    // to us
+  }
+};

--- a/lib/jscsrc-builder.js
+++ b/lib/jscsrc-builder.js
@@ -7,14 +7,41 @@ var temp = require('temp');
 
 temp.track();
 
+var messagesLogged = {};
+function logMessage(ui, message) {
+  // only log each message once, this prevents
+  // duplicate messages for `app` and `tests` trees
+  if (!messagesLogged[message]) {
+    ui.writeLine(message);
+    messagesLogged[message] = true;
+  }
+}
+
 function getCustomConfig() {
   if (fs.existsSync('.jscsrc')) {
     var contents = fs.readFileSync('.jscsrc', { encoding: 'utf8' });
 
     return JSON.parse(contents);
   } else {
-    return {};
+    return null;
   }
+}
+
+function getSuaveConfig() {
+  // avoiding `require` (which would have worked fine)
+  // to prevent mutating the cached result
+  var configPath = path.join(__dirname, 'jscsrc.json');
+  var contents = fs.readFileSync(configPath, { encoding: 'utf8' });
+
+  var suaveConfig = JSON.parse(contents);
+  // the rules specified there by default need to be
+  // deleted, because they are specified relative to
+  // ember-suave's root directory, and not the projects
+  // this is later replaced with the actual node_modules
+  // path
+  delete suaveConfig.additionalRules;
+
+  return suaveConfig;
 }
 
 function mergeConfigs(userConfig, suaveConfig) {
@@ -54,28 +81,58 @@ function hasEmberSuaveCustomRules(additionalRules) {
   return false;
 }
 
-module.exports = function(project) {
-  var userConfig = getCustomConfig();
-  var suaveConfig = require('./jscsrc');
+/*
+  When using `"preset": "ember-suave"` all processing in this file is avoided, and we
+  let JSCS do its normal preset processing. All other scenarios are deprecated with instructions
+  are provided in the deprecation message.
 
-  var jscsConfig = mergeConfigs(userConfig, suaveConfig);
+  This entire file can be removed when we no longer need to support non-preset usage.
+
+  TODO: Remove lib/jscsrc-builder.js for 2.0.0.
+*/
+
+module.exports = function(project) {
+  var ui = project && project.ui || { writeLine: function() {} };
+  var userConfig = getCustomConfig();
+  var suaveConfig = getSuaveConfig();
+  var jscsConfig, projectRoot, projectRules, customRulePath, info;
+
+  if (userConfig) {
+    if (userConfig.preset === 'ember-suave') {
+      // this is the happy path and short circuits all other logic
+      return '.jscsrc';
+    } else {
+      // when there is a `.jscsrc` but it doesn't include ember-suave as a preset
+      logMessage(ui, 'Your project\'s `.jscsrc` file does not include `ember-suave` as its preset. Please add `"preset": "ember-suave"` to your `.jscsrc` file.');
+    }
+  } else {
+    // when there is no .jscsrc file
+    logMessage(ui, 'Your project does not include a `.jscsrc` file. Please generate one via `ember generate ember-suave`.');
+  }
+
+  // everything here and below is for the deprecated cases
+  jscsConfig = mergeConfigs(userConfig || {}, suaveConfig);
 
   // Project custom rules
-  var projectRoot = project && project.root || process.cwd();
-  var projectRules = jscsConfig.additionalRules || [];
+  projectRoot = project && project.root || process.cwd();
+  projectRules = jscsConfig.additionalRules || [];
   jscsConfig.additionalRules = projectRules.map(function(rulePath) {
     return path.resolve(projectRoot, rulePath);
   });
 
   // Addon custom rules unless userConfig already included them
   if (!hasEmberSuaveCustomRules(jscsConfig.additionalRules)) {
-    var customRulePath = path.join(__dirname, 'rules');
+    customRulePath = path.join(__dirname, 'rules');
     jscsConfig.additionalRules.push(path.join(customRulePath, '*.js'));
   }
 
-  var info = temp.openSync('ember-suave');
+  info = temp.openSync('ember-suave');
   fs.writeSync(info.fd, JSON.stringify(jscsConfig));
   fs.closeSync(info.fd);
 
   return info.path;
+};
+
+module.exports.resetMessageLoggedStatus = function() {
+  messagesLogged = {};
 };

--- a/lib/jscsrc.json
+++ b/lib/jscsrc.json
@@ -2,6 +2,10 @@
   "esnext": true,
   "verbose": true,
 
+  "additionalRules": [
+    "./rules/*.js"
+  ],
+
   "disallowEmptyBlocks": true,
   "disallowKeywordsOnNewLine": ["else"],
   "disallowMultipleLineBreaks": true,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "broccoli-asset-rev": "^2.1.1",
     "chai": "^2.2.0",
     "ember-cli": "1.13.7",
+    "ember-cli-blueprint-test-helpers": "^0.3.0",
+    "ember-cli-internal-test-helpers": "^0.4.0",
     "ember-cli-release": "0.2.5",
     "jscs": "^2.0.0",
     "mocha": "^2.2.4",
@@ -32,7 +34,9 @@
     "walk-sync": "0.1.3"
   },
   "keywords": [
-    "ember-addon"
+    "ember-addon",
+    "jscs-preset",
+    "preset"
   ],
   "dependencies": {
     "broccoli-jscs": "^1.0.0",
@@ -40,9 +44,10 @@
     "temp": "0.8.3"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "main": "index.js"
   },
-  "main": "index.js",
+  "main": "lib/jscsrc.json",
   "bugs": {
     "url": "https://github.com/dockyard/ember-suave/issues"
   },

--- a/tests/blueprint-test.js
+++ b/tests/blueprint-test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
+var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
+var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+
+describe('Acceptance: ember generate and destroy ember-suave', function() {
+  setupTestHooks(this);
+
+  it('ember-suave', function() {
+    return generateAndDestroy(['ember-suave'], {
+      files: [
+        { file: '.jscsrc', contents: ['"preset": "ember-suave"'] }
+      ]
+    });
+  });
+});

--- a/tests/fixtures/.jscsrc
+++ b/tests/fixtures/.jscsrc
@@ -1,0 +1,1 @@
+{ "preset": "../../lib/jscsrc.json"}

--- a/tests/rules-test.js
+++ b/tests/rules-test.js
@@ -7,11 +7,12 @@ var suaveLintTree = require('../index').lintTree;
 
 describe('rules tests', function() {
   var fixturePath = path.join(__dirname, 'fixtures');
+  var jscsrcPath = path.join(fixturePath, '.jscsrc');
   var builder, originLog;
 
   beforeEach(function() {
     this.lintTree = suaveLintTree;
-    this.app = { options: {} };
+    this.app = { options: { jscsOptions: { configPath: jscsrcPath } } };
 
     originLog = console.log;
     console.log = function(contents) {


### PR DESCRIPTION
This PR removes the custom config file generation and replaces it with JSCS's built in preset system (thanks to @hzoo for helping push that forward so much!). This removes the need for a custom binary/command (because now `jscs` command will work properly).

I believe this is backwards compatible (if folks had created a `.jscsrc` file with our rules in them, they should continue to work just the same).  Definitely open to thoughts of how that might be an issue (worst case scenario we can just bump majors, but I'd prefer not to)...

Fixes #64.
Fixes #34.