### PR TITLE
Fixing QUnit check

### DIFF
--- a/vendor/ember-suave/test-loader.js
+++ b/vendor/ember-suave/test-loader.js
@@ -4,7 +4,7 @@ jQuery(document).ready(function () {
   var TestLoaderModule = require('ember-cli/test-loader');
   var addModuleExcludeMatcher = TestLoaderModule['addModuleExcludeMatcher'];
 
-  function isJscsDisabled() { return QUnit ? QUnit.urlParams.nojscs : false; }
+  function isJscsDisabled() { return typeof QUnit === 'undefined' ? false : QUnit.urlParams.nojscs; }
   function isAJscsTest(moduleName) { return moduleName.match(/\.jscs-test$/); }
   function jscsModuleMatcher(moduleName) { return isJscsDisabled() && isAJscsTest(moduleName); }
 


### PR DESCRIPTION
This pull request fixes this error when not using QUnit:

```
ReferenceError: Can't find variable: QUnit at http://localhost:7357/assets/test-support.js
```