### PR TITLE
Add rule for const outside of module scope.

### DIFF
--- a/lib/jscsrc.json
+++ b/lib/jscsrc.json
@@ -6,6 +6,7 @@
     "./rules/*.js"
   ],
 
+  "disallowConstOutsideModuleScope": true,
   "disallowEmptyBlocks": true,
   "disallowKeywordsOnNewLine": ["else"],
   "disallowMultipleLineBreaks": true,

--- a/lib/rules/disallow-const-outside-module-scope.js
+++ b/lib/rules/disallow-const-outside-module-scope.js
@@ -1,0 +1,38 @@
+var assert = require('assert');
+
+module.exports = function() { };
+
+module.exports.prototype = {
+  configure: function(option) {
+    assert(option === true, this.getOptionName() + ' requires a true value');
+  },
+
+  getOptionName: function() {
+    return 'disallowConstOutsideModuleScope';
+  },
+
+  check: function(file, errors) {
+    file.iterateNodesByType('VariableDeclaration', function(node) {
+      if (node.parentNode.type === 'Program') {
+        // declaration is in root of module
+        return;
+      }
+
+      if (node.parentNode.type === 'ExportNamedDeclaration' && node.parentNode.parentNode.type === 'Program') {
+        // declaration is a `export const foo = 'asdf'` in root of the module
+        return;
+      }
+
+      for (var i = 0; i < node.declarations.length; i++) {
+        var thisDeclaration = node.declarations[i];
+
+        if (thisDeclaration.parentNode.kind === 'const') {
+          errors.add(
+            '`const` should only be used in module scope (not inside functions/blocks).',
+            node.loc.start
+          );
+        }
+      }
+    });
+  }
+};

--- a/tests/fixtures/rules/disallow-const-outside-module-scope/bad/inside-function.js
+++ b/tests/fixtures/rules/disallow-const-outside-module-scope/bad/inside-function.js
@@ -1,0 +1,3 @@
+function something() {
+  const foo = 'bar';
+}

--- a/tests/fixtures/rules/disallow-const-outside-module-scope/bad/inside-if.js
+++ b/tests/fixtures/rules/disallow-const-outside-module-scope/bad/inside-if.js
@@ -1,0 +1,3 @@
+if (true) {
+  const foo = 'bar';
+}

--- a/tests/fixtures/rules/disallow-const-outside-module-scope/good/example.js
+++ b/tests/fixtures/rules/disallow-const-outside-module-scope/good/example.js
@@ -1,0 +1,6 @@
+const foo = 'blah';
+export const bar = 'derp';
+
+function something() {
+  let hey = 'you!';
+}


### PR DESCRIPTION
Good:

```js
const FOO = 'FOO';
```

Bad:

```js
function derp() {
  const FOO = 'FOO';
}

if (false) {
  const BLAH = 'BLAH';
}
```

---

I did not add configuration for this rule in the default preset (but I
can if we want it)...