### PR TITLE
Prevent errors when token is undefined.

### DIFF
--- a/lib/rules/require-template-strings-for-concatenation.js
+++ b/lib/rules/require-template-strings-for-concatenation.js
@@ -20,6 +20,11 @@ module.exports.prototype = {
       function assertIfTokenIsPlus(otherToken) {
         var nextToken = file.getNextToken(otherToken);
 
+        if (!otherToken || !nextToken) {
+          // there is no next or previous node
+          return;
+        }
+
         if (otherToken.type === 'Punctuator' &&
             otherToken.value === '+' &&
             otherToken.loc.start.line === token.loc.start.line &&

--- a/tests/fixtures/regressions/comment-before-first-token/example.js
+++ b/tests/fixtures/regressions/comment-before-first-token/example.js
@@ -1,0 +1,6 @@
+/* jshint node: true */
+
+// jscs:disable
+
+let foo = `stuff` +
+      `asdfa`;


### PR DESCRIPTION
Fixes #76.

---

We ultimately intend to remove this rule, but we should at least make it not error in the meantime...