### PR TITLE
Fix issue with updated deps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jscs": "^2.6.0",
     "mocha": "^2.2.4",
     "mocha-jshint": "^2.1.1",
-    "walk-sync": "0.1.3"
+    "walk-sync": "^0.2.6"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
If you `rm -rf node_modules && npm cache clear && npm install` on master, you will not be able to `npm test` because child deps need a newer version of `walkSync` than we have locked to.

This updates to latest walkSync and fixes that issue.