### PR TITLE
Add jscs-ember-deprecations.

### DIFF
--- a/lib/jscsrc.json
+++ b/lib/jscsrc.json
@@ -2,9 +2,27 @@
   "esnext": true,
   "verbose": true,
 
+  "plugins": [
+    "jscs-ember-deprecations"
+  ],
+
   "additionalRules": [
     "./rules/*.js"
   ],
+
+  "disallowObjectController": true,
+  "disallowInstanceInInitializer": true,
+  "disallowCoreView": true,
+  "disallowEmberTryCatch": true,
+  "disallowEmberRequired": true,
+  "disallowAtEachLeafNode": true,
+  "disallowArrayComputed": true,
+  "disallowReduceComputed": true,
+  "disallowEmberCreate": true,
+  "disallowEmberKeys": true,
+  "disallowEmberOneway": true,
+  "disallowEmberView": true,
+  "disallowPrototypeExtension": true,
 
   "disallowConstOutsideModuleScope": true,
   "disallowEmptyBlocks": true,

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "broccoli-jscs": "^1.0.0",
     "ember-cli-babel": "^5.0.0",
+    "jscs-ember-deprecations": "0.0.16",
     "temp": "0.8.3"
   },
   "ember-addon": {


### PR DESCRIPTION
Repo: https://github.com/minichate/jscs-ember-deprecations

Rules enabled here are those available in 0.0.16 of jscs-ember-deprecations:

* disallowObjectController
* disallowInstanceInInitializer
* disallowCoreView
* disallowEmberTryCatch
* disallowEmberRequired
* disallowAtEachLeafNode
* disallowArrayComputed
* disallowReduceComputed
* disallowPrototypeExtension - (forbids `.property()` and `.observes()`)
* disallowEmberCreate
* disallowEmberKeys
* disallowEmberOneway
* disallowEmberView

---

Fixes #82.

/cc @minichate