### PR TITLE
Specify JSCS config path

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ module.exports = {
   lintTree: function(type, tree) {
     var ui = this.ui;
     var jscsOptions = this.app.options.jscsOptions || {};
+    jscsOptions.configPath = jscsOptions.configPath || '.jscsrc';
+
     var jscsFilter = new JSCSFilter(tree, jscsOptions);
 
     jscsFilter.logError = function(errorText) {


### PR DESCRIPTION
`broccoli-jscs` doesn't actually default the config path to `.jscsrc` so we need to be explicit about it.

Closes #103