### PR TITLE
Disallowing accessing Ember properties directly

### DIFF
--- a/lib/jscsrc.json
+++ b/lib/jscsrc.json
@@ -15,6 +15,7 @@
   "disallowCoreView": true,
   "disallowEmberTryCatch": true,
   "disallowEmberRequired": true,
+  "disallowDirectPropertyAccess": ["Ember", "DS"],
   "disallowAtEachLeafNode": true,
   "disallowArrayComputed": true,
   "disallowReduceComputed": true,

--- a/lib/rules/disallow-direct-property-access.js
+++ b/lib/rules/disallow-direct-property-access.js
@@ -1,0 +1,39 @@
+var assert = require('assert');
+
+function DisallowDirectPropertyAccess() { }
+
+DisallowDirectPropertyAccess.prototype = {
+  configure: function(values) {
+    assert(
+      Array.isArray(values),
+      this.getOptionName() + ' option requires an array'
+    );
+    this._invalidNames = {};
+    for (var i = 0, l = values.length; i < l; i++) {
+      this._invalidNames[values[i]] = true;
+    }
+  },
+
+  getOptionName: function() {
+    return 'disallowDirectPropertyAccess';
+  },
+
+  check: function(file, errors) {
+    var invalidObjectNames = this._invalidNames;
+    file.iterateNodesByType('MemberExpression', function(node) {
+      if (node.parentNode.type === 'AssignmentExpression') {
+        // Avoid throwing the error if we're assigning to a property
+        return;
+      }
+      var objectName = node.object.name;
+      if (Object.prototype.hasOwnProperty.call(invalidObjectNames, objectName)) {
+        var propertyName = node.property.name;
+        errors.add(
+          'Avoid accessing ' + objectName + '.' + propertyName + ' directly',
+          node.loc.start);
+      }
+    });
+  }
+};
+
+module.exports = DisallowDirectPropertyAccess;

--- a/tests/fixtures/rules/disallow-direct-property-access/bad/ember-data.js
+++ b/tests/fixtures/rules/disallow-direct-property-access/bad/ember-data.js
@@ -1,0 +1,3 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({});

--- a/tests/fixtures/rules/disallow-direct-property-access/bad/ember.js
+++ b/tests/fixtures/rules/disallow-direct-property-access/bad/ember.js
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({});

--- a/tests/fixtures/rules/disallow-direct-property-access/good/assigning-properties.js
+++ b/tests/fixtures/rules/disallow-direct-property-access/good/assigning-properties.js
@@ -1,0 +1,2 @@
+Ember.MODEL_FACTORY_INJECTIONS = true;
+DS.SOME_PROPERTY = true;

--- a/tests/fixtures/rules/disallow-direct-property-access/good/ember-data.js
+++ b/tests/fixtures/rules/disallow-direct-property-access/good/ember-data.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+const { Model } = DS;
+
+export default Model.extend({});

--- a/tests/fixtures/rules/disallow-direct-property-access/good/ember.js
+++ b/tests/fixtures/rules/disallow-direct-property-access/good/ember.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({});

--- a/tests/fixtures/rules/require-spread/good/super.js
+++ b/tests/fixtures/rules/require-spread/good/super.js
@@ -1,4 +1,4 @@
-let Blah = Ember.Object.extend({
+let Blah = Foo.extend({
   init() {
     this._super(...arguments); // normal usage
 


### PR DESCRIPTION
Make referencing Ember (and Ember Data) properties directly illegal.

**Bad:**

```js
import Ember from 'ember';
export default Ember.Component.extend({ ... });
```

```js
import DS from 'ember-data';
export default Ember.Model.extend({ ... });
```

**Good:**

```js
import Ember from 'ember';

const { Component } = Ember;

export default Component.extend({ ... });
```

```js
import DS from 'ember-data';

const { Model } = DS;

export default Model.extend({ ... });
```

Closes #31