### PR TITLE
Require const for variables from Ember properties

### DIFF
--- a/lib/jscsrc.json
+++ b/lib/jscsrc.json
@@ -57,6 +57,7 @@
   "requireCapitalizedConstructors": true,
   "requireCommaBeforeLineBreak": true,
   "requireCommentsToIncludeAccess": true,
+  "requireConstForEmberProperties": true,
   "requireCurlyBraces": [
     "if",
     "else",

--- a/lib/rules/require-const-for-ember-properties.js
+++ b/lib/rules/require-const-for-ember-properties.js
@@ -35,7 +35,7 @@ RequireConstForEmberProperties.prototype = {
       if (variableFromEmber && node.kind !== 'const') {
         errors.add(
           'Always use `const` when making variables from Ember properties',
-          node.loc.start
+          node
         );
       }
     });

--- a/lib/rules/require-const-for-ember-properties.js
+++ b/lib/rules/require-const-for-ember-properties.js
@@ -1,0 +1,46 @@
+var assert = require('assert');
+
+function checkIdentifierError(declaration) {
+  var init = declaration.init;
+  return init.type === 'MemberExpression' && init.object.name === 'Ember';
+}
+
+function checkDestructuringError(declaration) {
+  return declaration.init.name === 'Ember';
+}
+
+function RequireConstForEmberProperties() { }
+
+RequireConstForEmberProperties.prototype = {
+  configure: function(option) {
+    assert(option === true, this.getOptionName() + ' requires a true value');
+  },
+
+  getOptionName: function() {
+    return 'requireConstForEmberProperties';
+  },
+
+  check: function(file, errors) {
+    file.iterateNodesByType('VariableDeclaration', function(node) {
+      var declaration = node.declarations[0];
+      var variableFromEmber = false;
+
+      // Check if the variable declaration comes from Ember
+      if (declaration.id.type === 'Identifier' && declaration.init) {
+        variableFromEmber = checkIdentifierError(declaration, errors);
+      } else if (declaration.id.type === 'ObjectPattern') {
+        variableFromEmber = checkDestructuringError(declaration, errors);
+      }
+
+      if (variableFromEmber && node.kind !== 'const') {
+        errors.add(
+          'Always use `const` when making variables from Ember properties',
+          node.loc.start
+        );
+      }
+    });
+  }
+
+};
+
+module.exports = RequireConstForEmberProperties;

--- a/tests/fixtures/rules/require-const-for-ember-properties/bad/destructuring-with-let.js
+++ b/tests/fixtures/rules/require-const-for-ember-properties/bad/destructuring-with-let.js
@@ -1,0 +1,1 @@
+var { isNone } = Ember;

--- a/tests/fixtures/rules/require-const-for-ember-properties/bad/destructuring-with-var.js
+++ b/tests/fixtures/rules/require-const-for-ember-properties/bad/destructuring-with-var.js
@@ -1,0 +1,1 @@
+let { isNone } = Ember;

--- a/tests/fixtures/rules/require-const-for-ember-properties/bad/destructuring.js
+++ b/tests/fixtures/rules/require-const-for-ember-properties/bad/destructuring.js
@@ -1,5 +1,0 @@
-// Let
-let { isNone } = Ember;
-
-// Var
-var { isNone } = Ember;

--- a/tests/fixtures/rules/require-const-for-ember-properties/bad/destructuring.js
+++ b/tests/fixtures/rules/require-const-for-ember-properties/bad/destructuring.js
@@ -1,0 +1,5 @@
+// Let
+let { isNone } = Ember;
+
+// Var
+var { isNone } = Ember;

--- a/tests/fixtures/rules/require-const-for-ember-properties/bad/member.js
+++ b/tests/fixtures/rules/require-const-for-ember-properties/bad/member.js
@@ -1,0 +1,2 @@
+// jscs:disable requireObjectDestructuring
+let isNone = Ember.isNone;

--- a/tests/fixtures/rules/require-const-for-ember-properties/good/destructuring.js
+++ b/tests/fixtures/rules/require-const-for-ember-properties/good/destructuring.js
@@ -1,0 +1,1 @@
+const { isNone } = Ember;

--- a/tests/fixtures/rules/require-const-for-ember-properties/good/member.js
+++ b/tests/fixtures/rules/require-const-for-ember-properties/good/member.js
@@ -1,3 +1,4 @@
 // jscs:disable requireObjectDestructuring
+// jscs:disable disallowDirectPropertyAccess
 const isNone = Ember.isNone;
 

--- a/tests/fixtures/rules/require-const-for-ember-properties/good/member.js
+++ b/tests/fixtures/rules/require-const-for-ember-properties/good/member.js
@@ -1,0 +1,3 @@
+// jscs:disable requireObjectDestructuring
+const isNone = Ember.isNone;
+


### PR DESCRIPTION
**Good:**

```js
const { isNone } = Ember;
const isNone = Ember.isNone;  // Allowed by this rule, disallowed by other included ones
```

**Bad:**

```js
let { isNone } = Ember;
let isNone = Ember.isNone;
```

Closes #8 