### PR TITLE
Add support for Mocha

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,32 @@
 'use strict';
 
 var JSCSFilter = require('broccoli-jscs');
+var jsStringEscape = require('js-string-escape');
 
 module.exports = {
   name: 'ember-suave',
 
   lintTree: function(type, tree) {
+    var project = this.project;
     var ui = this.ui;
     var jscsOptions = this.app.options.jscsOptions || {};
     jscsOptions.configPath = jscsOptions.configPath || '.jscsrc';
+
+    if (!jscsOptions.testGenerator && project.generateTestFile) {
+      jscsOptions.testGenerator = function(relativePath, errors) {
+        var passed = !errors || errors.length === 0;
+
+        if (errors) {
+          errors = jsStringEscape('\n' + errors);
+        }
+
+        return project.generateTestFile('JSCS - ' + relativePath, [{
+          name: 'should pass jscs',
+          passed: passed,
+          errorMessage: relativePath + ' should pass jscs.' + errors
+        }]);
+      };
+    }
 
     var jscsFilter = new JSCSFilter(tree, jscsOptions);
 

--- a/package.json
+++ b/package.json
@@ -39,8 +39,9 @@
     "preset"
   ],
   "dependencies": {
-    "broccoli-jscs": "^1.2.2",
+    "broccoli-jscs": "^1.4.0",
     "ember-cli-babel": "^5.1.6",
+    "js-string-escape": "^1.0.0",
     "jscs-ember-deprecations": "0.0.27",
     "temp": "0.8.3"
   },

--- a/tests/rules-test.js
+++ b/tests/rules-test.js
@@ -14,6 +14,7 @@ describe('rules tests', function() {
     this.lintTree = suaveLintTree;
     this.app = { options: { jscsOptions: { configPath: jscsrcPath } } };
     this.ui = { writeLine: function() {} };
+    this.project = {};
   });
 
   afterEach(function() {


### PR DESCRIPTION
Fixes https://github.com/DockYard/ember-suave/issues/58

This bumps the version of broccoli-jscs to 1.4, which now includes support for Mocha.

Support for Mocha was added to broccoli-jscs in https://github.com/kellyselden/broccoli-jscs/pull/59