### PR TITLE
excluding all node.js files as well as non-app files

### DIFF
--- a/blueprints/ember-suave/files/.jscsrc
+++ b/blueprints/ember-suave/files/.jscsrc
@@ -1,3 +1,8 @@
 {
-  "preset": "ember-suave"
+  "preset": "ember-suave",
+  "excludeFiles": [
+    "**",
+    "!app/**/*.js",
+    "!tests/**/*.js"
+  ]
 }


### PR DESCRIPTION
I continue to get errors in files such as `app/index.html` and `config/environment.js` which shouldn't need this enforcement