### PR TITLE
Update dependencies and use new blueprint testing API

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "broccoli": "0.16.9",
     "broccoli-asset-rev": "^2.4.2",
-    "chai": "^2.2.0",
+    "chai": "^3.5.0",
     "ember-cli": "1.13.15",
     "ember-cli-blueprint-test-helpers": "^0.8.0",
     "ember-cli-internal-test-helpers": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-cli-internal-test-helpers": "^0.8.1",
     "ember-cli-release": "1.0.0-beta.1",
     "jscs": "^2.9.0",
-    "mocha": "^2.2.4",
+    "mocha": "^2.4.5",
     "mocha-jshint": "^2.1.1",
     "walk-sync": "^0.2.6"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "broccoli": "0.16.9",
     "broccoli-asset-rev": "^2.4.2",
     "chai": "^3.5.0",
-    "ember-cli": "1.13.15",
+    "ember-cli": "2.4.3",
     "ember-cli-blueprint-test-helpers": "^0.8.0",
     "ember-cli-internal-test-helpers": "^0.8.1",
     "ember-cli-release": "1.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "broccoli-asset-rev": "^2.4.2",
     "chai": "^3.5.0",
     "ember-cli": "2.4.3",
-    "ember-cli-blueprint-test-helpers": "^0.8.0",
+    "ember-cli-blueprint-test-helpers": "^0.11.0",
     "ember-cli-internal-test-helpers": "^0.8.1",
     "ember-cli-release": "1.0.0-beta.1",
     "jscs": "^2.9.0",

--- a/tests/blueprint-test.js
+++ b/tests/blueprint-test.js
@@ -1,17 +1,25 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerate = blueprintHelpers.emberGenerate;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
+var file = chai.file;
 
 describe('Acceptance: ember generate and destroy ember-suave', function() {
   setupTestHooks(this);
 
   it('ember-suave', function() {
-    return generateAndDestroy(['ember-suave'], {
-      files: [
-        { file: '.jscsrc', contents: ['"preset": "ember-suave"'] }
-      ]
-    });
+    var args = ['ember-suave'];
+
+    return emberNew()
+      .then(() => emberGenerate(args))
+      .then(() => {
+        expect(file('.jscsrc'))
+          .to.contain('"preset": "ember-suave"');
+      });
   });
 });


### PR DESCRIPTION
This PR updates:

- mocha
- chai
- ember-cli
- ember-cli-blueprint-test-helpers

and uses the new blueprint testing API introduced in `ember-cli-blueprint-test-helpers@0.11.0`

/cc @trabus @rwjblue 