### PR TITLE
Update .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -34,6 +34,5 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
   "unused": true
 }


### PR DESCRIPTION
I always get this error:

Error: Config values to remove in 3.0:
The `esnext` option is enabled by default.