### PR TITLE
Don't cache the rules for tests

### DIFF
--- a/tests/rules-test.js
+++ b/tests/rules-test.js
@@ -12,7 +12,14 @@ describe('rules tests', function() {
 
   beforeEach(function() {
     this.lintTree = suaveLintTree;
-    this.app = { options: { jscsOptions: { configPath: jscsrcPath } } };
+    this.app = {
+      options: {
+        jscsOptions: {
+          configPath: jscsrcPath,
+          persist: false
+        }
+      }
+    };
     this.ui = { writeLine: function() {} };
     this.project = {};
   });


### PR DESCRIPTION
Set `jscsOptions.persist` to `false` so that tests can pick up any changes made to the rules.