### PR TITLE
Make compatible with ember-cli-qunit@2.0.0.

### DIFF
--- a/vendor/ember-suave/test-loader.js
+++ b/vendor/ember-suave/test-loader.js
@@ -1,7 +1,12 @@
-/* globals jQuery, QUnit */
+/* globals requirejs, jQuery, QUnit */
 
 jQuery(document).ready(function () {
-  var TestLoaderModule = require('ember-cli/test-loader');
+  var testLoaderModulePath = 'ember-cli-test-loader/test-support/index';
+  if (!requirejs.entries[testLoaderModulePath]) {
+    testLoaderModulePath = 'ember-cli/test-loader';
+  }
+
+  var TestLoaderModule = require(testLoaderModulePath);
   var addModuleExcludeMatcher = TestLoaderModule['addModuleExcludeMatcher'];
 
   function isJscsDisabled() { return typeof QUnit === 'undefined' ? false : QUnit.urlParams.nojscs; }


### PR DESCRIPTION
In ember-cli-qunit@2.0.0 `ember-cli-test-loader` is attempted to be loaded as an addon and falling back to the bower version if the addon is not present.

This change brings ember-suave in line with the changes in https://github.com/ember-cli/ember-cli-qunit/pull/113.