### PR TITLE
New rule: disallow-spaces-in-generator

### DIFF
--- a/lib/jscsrc.json
+++ b/lib/jscsrc.json
@@ -46,6 +46,9 @@
   "disallowSpacesInFunction": {
     "beforeOpeningRoundBrace": true
   },
+  "disallowSpacesInGenerator": {
+    "beforeStar": true
+  },
   "disallowSpacesInsideParentheses": true,
   "disallowSpacesInCallExpression": true,
   "disallowTrailingComma": true,

--- a/tests/fixtures/rules/disallow-spaces-in-generator/bad/anonymous-function.js
+++ b/tests/fixtures/rules/disallow-spaces-in-generator/bad/anonymous-function.js
@@ -1,0 +1,1 @@
+let foo = function *() {};

--- a/tests/fixtures/rules/disallow-spaces-in-generator/bad/function-declaration.js
+++ b/tests/fixtures/rules/disallow-spaces-in-generator/bad/function-declaration.js
@@ -1,0 +1,1 @@
+function * foo() {}

--- a/tests/fixtures/rules/disallow-spaces-in-generator/good/generator.js
+++ b/tests/fixtures/rules/disallow-spaces-in-generator/good/generator.js
@@ -1,0 +1,3 @@
+function* foo() {}
+
+let bar = function*() {};


### PR DESCRIPTION
Per discussion in #102.

```js
// Good
function* foo() {};
let bar = function*() {};

// Bad
let foo = function *() {};
function * foo() {};
```