### PR TITLE
Package has integrated forked changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-cli-babel": "^5.1.6",
     "js-string-escape": "^1.0.0",
     "jscs": "^3.0.4",
-    "jscs-ember-deprecations": "brzpegasus/jscs-ember-deprecations#5749615",
+    "jscs-ember-deprecations": "^2.3.0",
     "temp": "0.8.3"
   },
   "ember-addon": {


### PR DESCRIPTION
The upstream package that I maintain (jscs-ember-deprecations) has integrated the changes made in the fork.

I'm not sure whether or not you'd rather continue using the fork, but I thought I'd propose this change so that it'll (hopefully!?) be less confusing when users go hunting for the package.